### PR TITLE
ci(caching): restore package cache

### DIFF
--- a/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
+++ b/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Install poetry
         uses: snok/install-poetry@v1
 
+      - name: "Restore cached dependencies"
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
       - name: Install package
         run: poetry install
 
@@ -58,6 +66,14 @@ jobs:
 
       - name: Install poetry
         uses: snok/install-poetry@v1
+
+      - name: "Restore cached dependencies"
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
 
       - name: Install package
         run: poetry install


### PR DESCRIPTION
This adds a `Restore cached dependencies` step to the ci and cd jobs that tries to restored a cache of python packages (the ones stored in `~/.cache/poetry`).

I've added it to my own small project and it resulted in a 26x performance boost when fetching python dependency packages (from 3:05minutes to 7seconds).

This will only work when people commit the `poetry.lock` file to their repo as described [here](https://python-poetry.org/docs/basic-usage/#installing-with-poetrylock).

Without caching:

![Bildschirmfoto vom 2022-11-18 17-41-20](https://user-images.githubusercontent.com/193408/202811742-92839e8d-6868-423c-95c1-27c3bb0a1689.png)

With caching:

![Bildschirmfoto vom 2022-11-18 17-40-20](https://user-images.githubusercontent.com/193408/202811750-4528621a-cc4e-42cc-8221-4e22461a7945.png)
