### PR TITLE
🔧MAINT: update GH actions to latest versions

### DIFF
--- a/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
+++ b/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
@@ -10,12 +10,12 @@ jobs:
     # Define job steps
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "{{ cookiecutter.python_version }}"
 
       - name: Check-out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install poetry
         uses: snok/install-poetry@v1
@@ -27,7 +27,7 @@ jobs:
         run: poetry run pytest tests/ --cov={{ cookiecutter.__package_slug }} --cov-report=xml
 
       - name: Use Codecov to track coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml   # coverage report
 
@@ -47,12 +47,12 @@ jobs:
     # Define job steps
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "{{ cookiecutter.python_version }}"
 
       - name: Check-out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/{{ cookiecutter.__package_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.__package_slug }}/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
     # Define job steps
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "{{ cookiecutter.python_version }}"
 
       - name: Check-out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install poetry
         uses: snok/install-poetry@v1
@@ -27,7 +27,7 @@ jobs:
         run: poetry run pytest tests/ --cov={{ cookiecutter.__package_slug }} --cov-report=xml
 
       - name: Use Codecov to track coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml # coverage report
 


### PR DESCRIPTION
I had the following warning on my actions page

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v2, actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

So I updated the actions used in [ci.yml](https://github.com/py-pkgs/py-pkgs-cookiecutter/blob/main/%7B%7B%20cookiecutter.__package_slug%20%7D%7D/.github/workflows/ci.yml) and [ci-cd.yml](https://github.com/py-pkgs/py-pkgs-cookiecutter/blob/main/%7B%7B%20cookiecutter.__package_slug%20%7D%7D/.github/workflows/ci-cd.yml) to the latest available versions.