### PR TITLE
updated the cookiecutter .readthedocs.yml

### DIFF
--- a/{{ cookiecutter.__package_slug }}/.readthedocs.yml
+++ b/{{ cookiecutter.__package_slug }}/.readthedocs.yml
@@ -10,14 +10,18 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
-
+  jobs:
+    post_create_environment:
+      # Install poetry
+      # https://python-poetry.org/docs/#installing-manually
+      - pip install poetry
+      # Tell poetry to not use a virtual environment
+      - poetry config virtualenvs.create false
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      - poetry install
+      
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-    - requirements: docs/requirements.txt


### PR DESCRIPTION
This update allows us to install poetry and the package on ReadtheDocs so that `docs/example.ipynb` can be successfully executed. Previously `docs/example.ipynb` would throw an error about the package not being able to be found when it was attempted to be executed by ReadtheDocs.