### PR TITLE
updated cd workflow and Python Semantic Release table in pyproject.toml

### DIFF
--- a/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
+++ b/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
@@ -35,6 +35,10 @@ jobs:
         run: poetry run make html --directory docs/
 
   cd:
+    permissions:
+      id-token: write
+      contents: write
+    
     # Only run this job if the "ci" job passes
     needs: ci
 
@@ -56,27 +60,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install poetry
-        uses: snok/install-poetry@v1
-
-      - name: Install package
-        run: poetry install
-
       - name: Use Python Semantic Release to prepare release
-        env:
-          # This token is created automatically by GH Actions
-          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        run: |
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            poetry run semantic-release publish
+        id: release
+        uses: python-semantic-release/python-semantic-release@v8.3.0
+        with:
+          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.release.outputs.released == 'true'
         with:
-          user: __token__
+          repository-url: https://test.pypi.org/legacy/
           password: {% raw %}${{ secrets.TEST_PYPI_API_TOKEN }}{% endraw %}
-          repository_url: https://test.pypi.org/legacy/
 
       - name: Test install from TestPyPI
         run: |
@@ -87,6 +82,12 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.release.outputs.released == 'true'
         with:
-          user: __token__
           password: {% raw %}${{ secrets.PYPI_API_TOKEN }}{% endraw %}
+
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/upload-to-gh-release@main
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}


### PR DESCRIPTION
This new cd workflow the the following changes:

- uses  a GHA for Python Semantic Release instead of a command Python Semantic Release version 8.3.0
- upgraded to 
- drops the now redundant GHA commands (Install poetry, Install package)
- added a conditional to publish to the package repositories (only do this if semantic release has a new release
- used a GHA to generate the GitHub release

> Note: there is a bug in the newest versions of Python Semantic Release that prevent poetry from working (see [here](https://github.com/python-semantic-release/python-semantic-release/issues/723#issuecomment-1883056101)). Thus we are pinning to version 8.3.0 for now until the fix is merged to main/master.