### PR TITLE
Added if statement to test install from TestPyPI

### DIFF
--- a/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
+++ b/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
@@ -74,6 +74,7 @@ jobs:
           password: {% raw %}${{ secrets.TEST_PYPI_API_TOKEN }}{% endraw %}
 
       - name: Test install from TestPyPI
+        if: steps.release.outputs.released == 'true'
         run: |
             pip install \
             --index-url https://test.pypi.org/simple/ \


### PR DESCRIPTION
This if statement prevents a test install from TestPyPI if the PSR action did not create a new release. This is useful because it saves time, as well as prevents errors if no TestPyPI repository yet exists and PSR didn't make a version bump (can happen at the beginning of a project).