### PR TITLE
Patch codecov actions bump

### DIFF
--- a/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
+++ b/{{ cookiecutter.__package_slug }}/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Codecov to track coverage
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
           files: ./coverage.xml   # coverage report
 
       - name: Build documentation

--- a/{{ cookiecutter.__package_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.__package_slug }}/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Codecov to track coverage
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
           files: ./coverage.xml   # coverage report
 
       - name: Build documentation


### PR DESCRIPTION
I was missing the `{% raw %}` and `{% endraw %}` around `{% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}`. Closes #80 .