### PR TITLE
🐛FIX: remove packaging import

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,17 +1,22 @@
 import sys
-
-from importlib.metadata import distribution, PackageNotFoundError
-from packaging import version
+from importlib.metadata import (
+    PackageNotFoundError,
+    distribution,
+)
 
 MIN_CC_VERSION = "2.0.0"
 
+def version(v):
+    return tuple(map(int, (v.split("."))))
+
+
 # assert cookiecutter >= 2.0.0
 try:
-    cc_version = version.parse(distribution("cookiecutter").version)
+    cc_version = version(distribution("cookiecutter").version)
 except PackageNotFoundError:
     cc_version = None
 
-min_version = version.parse(MIN_CC_VERSION)
+min_version = version(MIN_CC_VERSION)
 if cc_version is None or cc_version < min_version:
     print(
         f"ERROR: Please install cookiecutter >= {MIN_CC_VERSION} "


### PR DESCRIPTION
Fixes #91 

Remove the import of `packaging` which may or may not exist for various reasons depending on environment and Python version.